### PR TITLE
get aws ecr token once

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -6,20 +6,8 @@ set -e
 # This is the order of arguments
 build_folder=$1
 aws_ecr_repository_url_with_tag=$2
+# kept for backwards compatibility
 aws_region=$3
-
-# Allow overriding the aws region from system
-if [ "$aws_region" != "" ]; then
-  aws_extra_flags="--region $aws_region"
-else
-  aws_extra_flags=""
-fi
-
-# Check that aws is installed
-which aws > /dev/null || { echo 'ERROR: aws-cli is not installed' ; exit 1; }
-
-# Connect into aws
-$(aws ecr get-login --no-include-email $aws_extra_flags) || { echo 'ERROR: aws ecr login failed' ; exit 1; }
 
 # Check that docker is installed and running
 which docker > /dev/null && docker ps > /dev/null || { echo 'ERROR: docker is not running' ; exit 1; }

--- a/examples/basic.tf
+++ b/examples/basic.tf
@@ -1,23 +1,40 @@
 # Create ECR repository
-resource "aws_ecr_repository" "test_service" {
-  name = "test_service"
+resource “aws_ecr_repository” “test_service” {
+  name = “test_service”
+}
+
+# Equivalent of aws ecr get-login
+data “aws_ecr_authorization_token” “ecr_token” {}
+
+# Multiple docker push commands can be run against a single token
+resource “null_resource” “renew_ecr_token” {
+  triggers = {
+    token_expired = data.aws_ecr_authorization_token.ecr_token.expires_at
+  }
+
+  provisioner “local-exec” {
+    command = “echo ${data.aws_ecr_authorization_token.ecr_token.password} | docker login —username ${data.aws_ecr_authorization_token.ecr_token.user_name} —password-stdin ${data.aws_ecr_authorization_token.ecr_token.proxy_endpoint}”
+  }
 }
 
 # Build docker image and push to ecr
 # From folder: ./test-service
-module "ecr_docker_build" {
-  source = "github.com/onnimonni/terraform-ecr-docker-build-module"
-  version = "0.1"
+module “ecr_docker_build” {
+  source = “github.com/onnimonni/terraform-ecr-docker-build-module”
+  version = “0.1”
 
   # Absolute path into the service which needs to be build
-  dockerfile_folder = "${path.module}/example-service-directory"
+  dockerfile_folder = “${path.module}/example-service-directory”
 
-  # Tag for the builded Docker image (Defaults to 'latest')
-  docker_image_tag = "development"
+  # Tag for the builded Docker image (Defaults to ‘latest’)
+  docker_image_tag = “development”
 
   # The region which we will log into with aws-cli
-  aws_region = "eu-west-1"
+  aws_region = “eu-west-1”
 
   # ECR repository where we can push
-  ecr_repository_url = "${aws_ecr_repository.test_service.repository_url}"
+  ecr_repository_url = “${aws_ecr_repository.test_service.repository_url}”
+  
+  # Acquire ecr auth token only once
+  depends_on = [null_resource.renew_ecr_token]
 }


### PR DESCRIPTION
Adds terraform code to acquire ecr token once prior to invoking the
module.  This solves a race condition where multiple parallel
invocations of the module using for_each were resulting in random
timeout failures while deploying multiple docker images at once.